### PR TITLE
Clarify exposing-to-internet instructions, add caddy example, remove backend port exposure in docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,37 @@ Once it's running, visit [localhost:4321](http://localhost:4321).
 
 #### Exposing to the internet/local network
 
-By default, the backend and frontend will only bind to `localhost`.
-Use a reverse proxy (like [caddy](https://caddyserver.com/) or [nginx](https://nginx.org/)) to forward the following ports:
-- 8080 TCP
-- 4321 TCP
+If you're exposing the app to the internet, you should set a `TURN_SECRET_KEY` environment variable when running the app:
 
-Expose the following ports for WebRTC:
-- 3478 TCP/UDP
-- 5349 TCP/UDP
-- 50000-50010 UDP
+```
+export TURN_SECRET_KEY=$(openssl rand -base64 32)
+docker compose up --build
+```
+
+Forward the following ports:
+- 4321 TCP (app)
+- 3478 TCP/UDP (WebRTC)
+- 5349 TCP/UDP (WebRTC)
+- 50000-50010 UDP (WebRTC)
+
+By default, the app only binds to `localhost`.
+You may change this in the [`docker-compose.yaml`](docker-compose.yaml#L10-L11) file, 
+but we suggest the use of a reverse proxy to expose port 4321 TCP.
+
+For example, with [caddy](https://caddyserver.com/):
+
+```
+# Caddyfile
+
+example.com {
+        # Optionally add basic authentication
+        basic_auth {
+                [username] [password-hash]
+        }
+
+        reverse_proxy localhost:4321
+}
+```
 
 ## Adding a game
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,10 +24,6 @@ services:
       # TODO is this shmem thing right
       shm_size: 2gb
     image: dweam_backend:local
-    # TODO can we remove this exposure?
-    #  are any API calls being made directly still, is the frontend making them during serverside/redirecting them?
-    ports:
-      - "127.0.0.1:8080:8080"
     environment:
       - INTERNAL_TURN_URL=turnserver:3478
       - TURN_SECRET_KEY=${TURN_SECRET_KEY}


### PR DESCRIPTION
Fixes #6 